### PR TITLE
Fixed spelling and formatting, added explanation of commands

### DIFF
--- a/subsystems/container-internals-lab-2-0-part-1/02-images.md
+++ b/subsystems/container-internals-lab-2-0-part-1/02-images.md
@@ -8,7 +8,7 @@ But let's dig into three concepts a little deeper:
 
 `podman pull fedora`{{execute}}
 
-2. Compatibility: This addressses the content inside the container image. No matter how hard you try, ARM binaries in a container image will not run on POWER container hosts. Containers do not offer compatibility guarantees; only virtualization can do that. This compatibility problem extends to processor architecture, and also versions of the operating system. Try running a RHEL 8 container image on a RHEL 4 container host -- that isn't going to work. However, as long as the operating systems are reasonably similar, the binaries in the container image will usually run. Note that executing basic commands with a Fedora image work even though this isn't a Fedora container host:
+2. Compatibility: This addresses the content inside the container image. No matter how hard you try, ARM binaries in a container image will not run on POWER container hosts. Containers do not offer compatibility guarantees; only virtualization can do that. This compatibility problem extends to processor architecture, and also versions of the operating system. Try running a RHEL 8 container image on a RHEL 4 container host -- that isn't going to work. However, as long as the operating systems are reasonably similar, the binaries in the container image will usually run. Note that executing basic commands with a Fedora image work even though this isn't a Fedora container host:
 
 `podman run -t fedora cat /etc/redhat-release`{{execute}}
 
@@ -24,7 +24,7 @@ However, there are limits. Red Hat can't guarantee that RHEL 5, Fedora, and Alpi
 
 ![Mismatching Container Image and Host](../../assets/subsystems/container-internals-lab-2-0-part-1/02-container-image-host-mismatch.png)
 
-This leads us to supportability as a concept seperate from portability and compatibility. This is the ability to guarantee to some level that certain images will work on certain hosts. Red Hat can do this between selected major versions of RHEL for the same reason that we can do it with the [RHEL Application Compatibility Guide](https://access.redhat.com/articles/rhel-abi-compatibility). We take special precautions to compile our programs in a way that doesn't break compatibility, we analyze CVEs, and we test performance. A bare minimum of testing, security, and performance can go a long way in ensureing supportability between versions of Linux, but there are limits. One should not expect that container images from RHEL 9, 10, or 11 will run on RHEL 8 hosts.
+This leads us to supportability as a concept seperate from portability and compatibility. This is the ability to guarantee to some level that certain images will work on certain hosts. Red Hat can do this between selected major versions of RHEL for the same reason that we can do it with the [RHEL Application Compatibility Guide](https://access.redhat.com/articles/rhel-abi-compatibility). We take special precautions to compile our programs in a way that doesn't break compatibility, we analyze CVEs, and we test performance. A bare minimum of testing, security, and performance can go a long way in ensuring supportability between versions of Linux, but there are limits. One should not expect that container images from RHEL 9, 10, or 11 will run on RHEL 8 hosts.
 
 ![Container Image & Host Supportability](../../assets/subsystems/container-internals-lab-2-0-part-1/02-container-image-host-supportability.png)
 

--- a/subsystems/container-internals-lab-2-0-part-1/05-orchestration.md
+++ b/subsystems/container-internals-lab-2-0-part-1/05-orchestration.md
@@ -22,7 +22,7 @@ Take a quick look at this YAML file but don't don't get too worried if you don't
 `curl https://raw.githubusercontent.com/fatherlinux/two-pizza-team/master/two-pizza-team-ubi.yaml`{{execute}}
 
 
-In the "database," we are opening a file and using netcat to ship it over port 3306. In the "web app," we are pulling in the data from port 3306, and shipping it back out over port 80 like a normal application would. The idea is to show a simple example of how powerful this is without having to learn other technology. We are able to fire this application up in an instant with a single *oc* command:
+In the "database," we are opening a file and using netcat to ship it over port 3306. In the "web app", we are pulling in the data from port 3306, and shipping it back out over port 80 like a normal application would. The idea is to show a simple example of how powerful this is without having to learn other technology. We are able to fire this application up in an instant with a single *oc* command:
 
 `oc create -f https://raw.githubusercontent.com/fatherlinux/two-pizza-team/master/two-pizza-team-ubi.yaml`{{execute}}
 
@@ -30,9 +30,13 @@ Wait for the cheese-pizza and pepperoni pizza pods to start:
 
 `for i in {1..5}; do oc get pods;sleep 3; done`{{execute}}
 
-When the pods are done being created, pull some data from our newly created "web app."  Notice that we get back the contents of a file which resides on the the database server, not the web server:
+Wait until all pods are are in status "RUNNING".
+
+When the pods are done being created, pull some data from our newly created "web app".  Notice that we get back the contents of a file which resides on the the database server, not the web server:
 
 `curl $(kubectl get svc pepperoni-pizza -o yaml | grep ip | awk '{print $3}')`{{execute}}
+
+Note: The command in brackets above is simply getting the IP address of the web server.
 
 Now, let's pull data directly from the "database."  It's the same file as we would expect, but this time coming back over port 3306:
 


### PR DESCRIPTION
Very minor updates to spelling and placement of double quotes.  Added a little explanation of the use of a kubectl command that's just fetching an IP address.