### PR TITLE
Minor wording/usability change

### DIFF
--- a/subsystems/container-internals-lab-2-0-part-4/02-create-container.md
+++ b/subsystems/container-internals-lab-2-0-part-4/02-create-container.md
@@ -47,11 +47,7 @@ The above command errors out because the container engine hasn't created the con
 
 Now, the config.json file has been created. Inspect it for a while. Notice that there are options in there that are strikingly similar to the command line options of podman. The spec file really highlights the API:
 
-`cat /var/lib/containers/storage/overlay-containers/$(podman ps -l -q --no-trunc)/userdata/config.json|jq . | less`{{execute}}
-
-Now, exit:
-
-`q`{{execute}}
+`cat /var/lib/containers/storage/overlay-containers/$(podman ps -l -q --no-trunc)/userdata/config.json|jq .`{{execute}}
 
 Podman has not started a container, just created the config.json and immediately exited. Notice under the STATUS column, that the container is now in the Exited state:
 

--- a/subsystems/container-internals-lab-2-0-part-4/03-selinux-svirt.md
+++ b/subsystems/container-internals-lab-2-0-part-4/03-selinux-svirt.md
@@ -11,7 +11,7 @@ Example Output:
 ``system_u:system_r:container_t:s0:c228,c810 root 18682 18669  0 03:30 pts/0 00:00:00 sleep 10
 system_u:system_r:container_t:s0:c184,c827 root 18797 18785  0 03:30 pts/0 00:00:00 sleep 10``
 
-Notice that each container is labeled with a dynamically generated [Multi Level Security (MLS)](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/mls) label. In the example below, the first container has an MLS label of c228,c810 while the second has a label of c184,c827. Since each of these containers is started with a different MLS label, they are prevented from accessing each other's memory, files, etc.
+Notice that each container is labeled with a dynamically generated [Multi Level Security (MLS)](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/mls) label. In the example above, the first container has an MLS label of c228,c810 while the second has a label of c184,c827. Since each of these containers is started with a different MLS label, they are prevented from accessing each other's memory, files, etc.
 
 SELinux doesn't just label the processes, it must also labels the files accessed by the process. Make a directory for data, and inspect the SELinux label on the directory. Notice the type is set to "user_tmp_t" but there are no MLS labels set:
 


### PR DESCRIPTION
I ran through Lab 1 and Lab 4 for RHTE and came across these 2 things.

1) Piping output to `less` doesn't go well in Katacoda. It messed with scrolling and the content doesn't display correctly on screen.
2) Reference to an example that is "below" that's above it instead.